### PR TITLE
Removed unnecessary header

### DIFF
--- a/Assets/Scripts/DeliveryExperiment.cs
+++ b/Assets/Scripts/DeliveryExperiment.cs
@@ -19,7 +19,6 @@ using MathNet.Numerics.Distributions;
 using static MessageImageDisplayer;
 using static WorldDataReporter;
 using UnityEngine.AI;
-using static UnityEditor.PlayerSettings;
 
 [System.Serializable]
 public struct Environment

--- a/Assets/StreamingAssets/UnityServicesProjectConfiguration.json
+++ b/Assets/StreamingAssets/UnityServicesProjectConfiguration.json
@@ -1,1 +1,0 @@
-{"Keys":["com.unity.services.core.version"],"Values":[{"m_Value":"1.3.1","m_IsReadOnly":true}]}

--- a/Assets/StreamingAssets/UnityServicesProjectConfiguration.json.meta
+++ b/Assets/StreamingAssets/UnityServicesProjectConfiguration.json.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 521b24ae0825c4285b28d09901ad4a40
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
The header "using static UnityEditor.PlayerSettings;" was unnecessary and caused errors when building the project.